### PR TITLE
Fetch wrappers plus relationship and property fetching modifiers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,51 @@
 {
-  "originHash" : "e20f8927be6a812a24e179daf609cea000f5183b4e82a359a776395ad55774cc",
+  "originHash" : "228651f057f3c5a137ab88110b3418414a73d28dc6330c6ac36c9d3146aded7b",
   "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "eefcdaa88d2e2fd82e3405dfb6eb45872011a0b5",
+        "version" : "1.9.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
     {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.8.1"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.3"),
     ],
     targets: [
@@ -25,7 +26,9 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "SwiftQuery",
-            dependencies: []
+            dependencies: [
+                .product(name: "Dependencies", package: "swift-dependencies")
+            ]
         ),
         .testTarget(
             name: "SwiftQueryTests",

--- a/README.md
+++ b/README.md
@@ -166,15 +166,10 @@ Person[0..<5]
 When you know you'll need related objects, you can prefetch relationships to reduce trips to the persistent store:
 
 ```swift
-// Prefetch a single relationship
-let ordersWithCustomers = Order
-    .include(#Predicate { $0.status == .active })
-    .prefetchRelationship(\.customer)
-
 // Prefetch multiple relationships
 let ordersWithDetails = Order
-    .prefetchRelationship(\.customer)
-    .prefetchRelationship(\.items)
+    .include(#Predicate { $0.status == .active })
+    .prefetchRelationships(\.customer, \.items)
 ```
 
 #### Fetching specific properties

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ let ordersWithDetails = Order
     .prefetchRelationship(\.items)
 ```
 
-### Fetching results
+### Executing queries
 
 Queries are just descriptions of how to fetch objects from a context. To make them 
 useful, we want to be able to perform them. When fetching results on the main actor,

--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ let ordersWithDetails = Order
     .prefetchRelationship(\.items)
 ```
 
+#### Fetching specific properties
+
+To reduce memory usage, you can fetch only specific properties instead of full objects:
+
+```swift
+// Fetch only specific properties for better performance
+let lightweightPeople = Person.fetchKeyPaths(\.name, \.age)
+```
+
 ### Executing queries
 
 Queries are just descriptions of how to fetch objects from a context. To make them 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ been applied to this query, we'll just get the first five results:
 Person[0..<5]
 ```
 
+#### Prefetching relationships
+
+To improve performance when you know you'll need related objects, you can prefetch relationships to reduce database trips:
+
+```swift
+// Prefetch a single relationship
+let ordersWithCustomers = Order
+    .include(#Predicate { $0.status == .active })
+    .prefetchRelationship(\.customer)
+
+// Prefetch multiple relationships
+let ordersWithDetails = Order
+    .prefetchRelationship(\.customer)
+    .prefetchRelationship(\.items)
+```
+
 ### Fetching results
 
 Queries are just descriptions of how to fetch objects from a context. To make them 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Person[0..<5]
 
 #### Prefetching relationships
 
-To improve performance when you know you'll need related objects, you can prefetch relationships to reduce database trips:
+When you know you'll need related objects, you can prefetch relationships to reduce trips to the persistent store:
 
 ```swift
 // Prefetch a single relationship

--- a/Sources/SwiftQuery/FetchWrappers/DefaultModelContainerKey.swift
+++ b/Sources/SwiftQuery/FetchWrappers/DefaultModelContainerKey.swift
@@ -1,0 +1,30 @@
+import Dependencies
+import SwiftData
+
+@Model final class Empty {
+    init() {}
+}
+
+enum DefaultModelContainerKey: DependencyKey {
+    static var liveValue: ModelContainer {
+        reportIssue(
+      """
+      A blank, in-memory persistent container is being used for the app.
+      Override this dependency in the entry point of your app using `prepareDependencies`.
+      """
+        )
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try! ModelContainer(for: Empty.self, configurations: configuration)
+    }
+
+    static var testValue: ModelContainer {
+        liveValue
+    }
+}
+
+public extension DependencyValues {
+    var modelContainer: ModelContainer {
+        get { self[DefaultModelContainerKey.self] }
+        set { self[DefaultModelContainerKey.self] = newValue }
+    }
+}

--- a/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CoreData
+import Dependencies
+import SwiftData
+
+@MainActor
+@propertyWrapper
+public final class FetchAll<Model: PersistentModel> {
+    public var wrappedValue: [Model] = []
+    private var subscription: Task<Void, Never> = Task { }
+
+    public init(_ query: Query<Model>) {
+        subscribe(fetchDescriptor: query.fetchDescriptor)
+    }
+
+    deinit {
+        subscription.cancel()
+    }
+
+    private func subscribe(fetchDescriptor: FetchDescriptor<Model>) {
+        debug { logger.debug("\(Self.self).\(#function)") }
+        subscription = Task { @MainActor in
+            // Send initial value
+            do {
+                @Dependency(\.modelContainer) var modelContainer
+                wrappedValue = try modelContainer.mainContext.fetch(fetchDescriptor)
+
+                // Listen for changes
+                let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)
+
+                for try await _ in changeNotifications {
+                    guard !Task.isCancelled else { break }
+                    debug { logger.debug("\(Self.self).NSPersistentStoreRemoteChange")}
+                    let result = try modelContainer.mainContext.fetch(fetchDescriptor)
+                    trace {
+                        logger.trace("\(Self.self).fetchedResults: \(String(describing: result.map { $0.persistentModelID } ))")
+                    }
+                    wrappedValue = result
+                }
+            } catch {
+                logger.error("\(error)")
+            }
+        }
+    }
+}

--- a/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
@@ -2,14 +2,17 @@ import Foundation
 import CoreData
 import Dependencies
 import SwiftData
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 @MainActor
 @propertyWrapper
-public final class FetchAll<Model: PersistentModel> {
+public final class FetchAll<Model: PersistentModel>: Observable {
     public var wrappedValue: [Model] = []
     private var subscription: Task<Void, Never> = Task { }
 
-    public init(_ query: Query<Model>) {
+    public init(_ query: Query<Model> = .init()) {
         subscribe(fetchDescriptor: query.fetchDescriptor)
     }
 
@@ -43,3 +46,7 @@ public final class FetchAll<Model: PersistentModel> {
         }
     }
 }
+
+#if canImport(SwiftUI)
+extension FetchAll: DynamicProperty {}
+#endif

--- a/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchAll.swift
@@ -2,9 +2,6 @@ import Foundation
 import CoreData
 import Dependencies
 import SwiftData
-#if canImport(SwiftUI)
-import SwiftUI
-#endif
 
 @MainActor
 @propertyWrapper
@@ -57,7 +54,3 @@ public final class FetchAll<Model: PersistentModel>: Observable {
         init() {}
     }
 }
-
-#if canImport(SwiftUI)
-extension FetchAll: DynamicProperty {}
-#endif

--- a/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
@@ -1,0 +1,41 @@
+import Foundation
+import CoreData
+import Dependencies
+import SwiftData
+
+@MainActor
+@propertyWrapper
+public final class FetchFirst<Model: PersistentModel> {
+    public var wrappedValue: Model? = nil
+    private var subscription: Task<Void, Never> = Task { }
+
+    public init(_ query: Query<Model>) {
+        subscribe(fetchDescriptor: query.fetchDescriptor)
+    }
+
+    deinit {
+        subscription.cancel()
+    }
+
+    private func subscribe(fetchDescriptor: FetchDescriptor<Model>) {
+        debug { logger.debug("\(Self.self).\(#function)") }
+        subscription = Task {
+            do {
+                @Dependency(\.modelContainer) var modelContainer
+                wrappedValue = try modelContainer.mainContext.fetch(fetchDescriptor).first
+
+                let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)
+
+                for try await _ in changeNotifications {
+                    guard !Task.isCancelled else { break }
+                    debug { logger.debug("\(Self.self).NSPersistentStoreRemoteChange")}
+                    let result = try modelContainer.mainContext.fetch(fetchDescriptor).first
+                    trace { logger.trace("\(Self.self).fetchedResults: \(String(describing: result?.persistentModelID))") }
+                    wrappedValue = result
+                }
+            } catch {
+                logger.error("\(error)")
+            }
+        }
+    }
+}

--- a/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
@@ -6,10 +6,10 @@ import SwiftData
 @MainActor
 @propertyWrapper
 public final class FetchFirst<Model: PersistentModel> {
-    private var storage: Storage = .init()
     public var wrappedValue: Model? {
         storage.wrappedValue
     }
+    private var storage: Storage = .init()
     private var subscription: (Task<Void, Never>)?
     @Dependency(\.modelContainer) private var modelContainer
 
@@ -26,7 +26,7 @@ public final class FetchFirst<Model: PersistentModel> {
         subscription = Task { [modelContainer = self.modelContainer] in
             do {
                 let initialResult = try query.first(in: modelContainer)
-                trace { logger.trace("\(Self.self).initialResult: \(String(describing: initialResult?.persistentModelID))") }
+                trace { logger.trace("\(Self.self).first: \(String(describing: initialResult?.persistentModelID))") }
                 storage.wrappedValue = initialResult
 
                 let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)
@@ -35,7 +35,7 @@ public final class FetchFirst<Model: PersistentModel> {
                     guard !Task.isCancelled else { break }
                     debug { logger.debug("\(Self.self).NSPersistentStoreRemoteChange")}
                     let result = try query.first(in: modelContainer)
-                    trace { logger.trace("\(Self.self).fetchedResults: \(String(describing: result?.persistentModelID))") }
+                    trace { logger.trace("\(Self.self).first: \(String(describing: result?.persistentModelID))") }
                     storage.wrappedValue = result
                 }
             } catch {

--- a/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchFirst.swift
@@ -26,6 +26,7 @@ public final class FetchFirst<Model: PersistentModel> {
         subscription = Task { [modelContainer = self.modelContainer] in
             do {
                 let initialResult = try query.first(in: modelContainer)
+                trace { logger.trace("\(Self.self).initialResult: \(String(describing: initialResult?.persistentModelID))") }
                 storage.wrappedValue = initialResult
 
                 let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)

--- a/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
@@ -2,9 +2,6 @@ import Foundation
 import CoreData
 import Dependencies
 import SwiftData
-#if canImport(SwiftUI)
-import SwiftUI
-#endif
 
 @MainActor
 @propertyWrapper
@@ -58,7 +55,3 @@ public final class FetchResults<Model: PersistentModel> {
         init() {}
     }
 }
-
-#if canImport(SwiftUI)
-extension FetchResults: DynamicProperty {}
-#endif

--- a/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CoreData
+import Dependencies
+import SwiftData
+
+@MainActor
+@propertyWrapper
+public final class FetchResults<Model: PersistentModel> {
+    public var wrappedValue: FetchResultsCollection<Model>?
+    private var subscription: Task<Void, Never> = Task { }
+
+    public init(_ query: Query<Model>, batchSize: Int = 20) {
+        subscribe(fetchDescriptor: query.fetchDescriptor, batchSize: batchSize)
+    }
+
+    deinit {
+        subscription.cancel()
+    }
+
+    private func subscribe(fetchDescriptor: FetchDescriptor<Model>, batchSize: Int) {
+        debug { logger.debug("\(Self.self).\(#function)") }
+        subscription = Task {
+            do {
+                @Dependency(\.modelContainer) var modelContainer
+                var descriptor = fetchDescriptor
+                descriptor.includePendingChanges = false
+                wrappedValue = try modelContainer.mainContext.fetch(descriptor, batchSize: batchSize)
+
+                let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)
+
+                for try await _ in changeNotifications {
+                    guard !Task.isCancelled else { break }
+                    debug { logger.debug("\(Self.self).NSPersistentStoreRemoteChange")}
+                    let result = try modelContainer.mainContext.fetch(descriptor, batchSize: batchSize)
+                    trace {
+                        logger.trace("\(Self.self).fetchedResults: \(String(describing: result.map { $0.persistentModelID } ))")
+                    }
+                    wrappedValue = result
+                }
+            } catch {
+                logger.error("\(error)")
+            }
+        }
+    }
+}

--- a/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
@@ -2,6 +2,9 @@ import Foundation
 import CoreData
 import Dependencies
 import SwiftData
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 @MainActor
 @propertyWrapper
@@ -43,3 +46,7 @@ public final class FetchResults<Model: PersistentModel> {
         }
     }
 }
+
+#if canImport(SwiftUI)
+extension FetchResults: DynamicProperty {}
+#endif

--- a/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
+++ b/Sources/SwiftQuery/FetchWrappers/FetchResults.swift
@@ -9,41 +9,53 @@ import SwiftUI
 @MainActor
 @propertyWrapper
 public final class FetchResults<Model: PersistentModel> {
-    public var wrappedValue: FetchResultsCollection<Model>?
-    private var subscription: Task<Void, Never> = Task { }
+    public var wrappedValue: FetchResultsCollection<Model>? {
+        storage.wrappedValue
+    }
+    private var storage: Storage = .init()
+    private var subscription: (Task<Void, Never>)?
+    @Dependency(\.modelContainer) private var modelContainer
 
     public init(_ query: Query<Model>, batchSize: Int = 20) {
-        subscribe(fetchDescriptor: query.fetchDescriptor, batchSize: batchSize)
+        subscribe(query, batchSize: batchSize)
     }
 
     deinit {
-        subscription.cancel()
+        subscription?.cancel()
     }
 
-    private func subscribe(fetchDescriptor: FetchDescriptor<Model>, batchSize: Int) {
+    private func subscribe(_ query: Query<Model>, batchSize: Int) {
         debug { logger.debug("\(Self.self).\(#function)") }
         subscription = Task {
             do {
-                @Dependency(\.modelContainer) var modelContainer
-                var descriptor = fetchDescriptor
-                descriptor.includePendingChanges = false
-                wrappedValue = try modelContainer.mainContext.fetch(descriptor, batchSize: batchSize)
+                
+                let initialResult = try query.fetchedResults(in: modelContainer, batchSize: batchSize)
+                trace {
+                    logger.trace("\(Self.self).fetchedResults: \(String(describing: initialResult.map { $0.persistentModelID } ))")
+                }
+                storage.wrappedValue = initialResult
 
                 let changeNotifications = NotificationCenter.default.notifications(named: .NSPersistentStoreRemoteChange)
 
                 for try await _ in changeNotifications {
                     guard !Task.isCancelled else { break }
                     debug { logger.debug("\(Self.self).NSPersistentStoreRemoteChange")}
-                    let result = try modelContainer.mainContext.fetch(descriptor, batchSize: batchSize)
+                    let result = try query.fetchedResults(in: modelContainer, batchSize: batchSize)
                     trace {
                         logger.trace("\(Self.self).fetchedResults: \(String(describing: result.map { $0.persistentModelID } ))")
                     }
-                    wrappedValue = result
+                    storage.wrappedValue = result
                 }
             } catch {
                 logger.error("\(error)")
             }
         }
+    }
+
+    @Observable
+    internal class Storage {
+        var wrappedValue: FetchResultsCollection<Model>?
+        init() {}
     }
 }
 

--- a/Sources/SwiftQuery/Logging.swift
+++ b/Sources/SwiftQuery/Logging.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OSLog
+
+let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "",
+    category: "SwiftDataSharing"
+)
+
+func debug(_ operation: () -> Void) {
+    if
+        let isEnabledArgument = ProcessInfo.processInfo.environment["com.impossibleflight.SwiftQuery.debug"],
+        let isEnabled = Bool(isEnabledArgument)
+    {
+        if isEnabled {
+            operation()
+        }
+    }
+}
+
+func trace(_ operation: () -> Void) {
+    if
+        let isEnabledArgument = ProcessInfo.processInfo.environment["com.impossibleflight.SwiftQuery.trace"],
+        let isEnabled = Bool(isEnabledArgument)
+    {
+        if isEnabled {
+            operation()
+        }
+    }
+}

--- a/Sources/SwiftQuery/Logging.swift
+++ b/Sources/SwiftQuery/Logging.swift
@@ -3,7 +3,7 @@ import OSLog
 
 let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "",
-    category: "SwiftDataSharing"
+    category: "SwiftQuery"
 )
 
 func debug(_ operation: () -> Void) {

--- a/Sources/SwiftQuery/PersistentModel+Fetch.swift
+++ b/Sources/SwiftQuery/PersistentModel+Fetch.swift
@@ -2,66 +2,74 @@ import SwiftData
 
 @MainActor
 public extension PersistentModel {
-    /// Builds a query over this model type and invokes ``Query/first(in:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/first(in:)`` on that query.
     /// This is named `any` rather than `first` because there is no order.
     static func any(in container: ModelContainer) throws -> Self? {
         try query().first(in: container)
     }
 
-    /// Builds a query over this model type and invokes ``Query/results(in:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/results(in:)`` on that query.
     static func results(in container: ModelContainer) throws -> [Self] {
         try query().results(in: container)
     }
 
-    /// Builds a query over this model type and invokes ``Query/fetchedResults(in:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/fetchedResults(in:)`` on that query.
     static func fetchedResults(in container: ModelContainer) throws -> FetchResultsCollection<Self> {
         try query().fetchedResults(in: container)
     }
 
-    /// Builds a query over this model type and invokes ``Query/fetchedResults(in:batchSize:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/fetchedResults(in:batchSize:)`` on that query.
     static func fetchedResults(in container: ModelContainer, batchSize: Int) throws -> FetchResultsCollection<Self> {
         try query().fetchedResults(in: container, batchSize: batchSize)
     }
 
-    /// Builds a query over this model type and invokes ``Query/count(in:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/count(in:)`` on that query.
     static func count(in container: ModelContainer) throws -> Int {
         try query().count(in: container)
     }
 
-    /// Builds a query over this model type and invokes ``Query/isEmpty(in:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/isEmpty(in:)`` on that query.
     static func isEmpty(in container: ModelContainer) throws -> Bool {
         try query().isEmpty(in: container)
     }
 
-    /// Builds a query over this model type and invokes ``Query/findOrCreate(in:body:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/findOrCreate(in:body:)`` on that query.
     static func findOrCreate(
         in container: ModelContainer,
         body: () -> Self
     ) throws -> Self {
         try query().findOrCreate(in: container, body: body)
     }
+
+    /// Constructs an empty query over this model type and invokes ``Query/delete(in:)`` on that query.
+    /// This is named `deleteAll` rather than `delete` to signify with an empty query this will match all objects.
+    static func deleteAll(
+        in container: ModelContainer
+    ) throws {
+        try query().delete(in: container)
+    }
 }
 
 public extension PersistentModel {
-    /// Builds a query over this model type and invokes ``Query/first(isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/first(isolation:)`` on that query.
     /// This is named `any` rather than `first` because there is no order.
     static func any(isolation: isolated (any ModelActor) = #isolation) throws -> Self? {
         try query().first()
     }
 
-    /// Builds a query over this model type and invokes ``Query/results(isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/results(isolation:)`` on that query.
     static func results(isolation: isolated (any ModelActor) = #isolation) throws -> [Self] {
         try query().results()
     }
 
-    /// Builds a query over this model type and invokes ``Query/fetchedResults(isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/fetchedResults(isolation:)`` on that query.
     static func fetchedResults(
         isolation: isolated (any ModelActor) = #isolation
     ) throws -> FetchResultsCollection<Self>  {
         try query().fetchedResults()
     }
 
-    /// Builds a query over this model type and invokes ``Query/fetchedResults(batchSize:isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/fetchedResults(batchSize:isolation:)`` on that query.
     static func fetchedResults(
         batchSize: Int,
         isolation: isolated (any ModelActor) = #isolation
@@ -69,21 +77,29 @@ public extension PersistentModel {
         try query().fetchedResults(batchSize: batchSize)
     }
 
-    /// Builds a query over this model type and invokes ``Query/count(isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/count(isolation:)`` on that query.
     static func count(isolation: isolated (any ModelActor) = #isolation) throws -> Int {
         try query().count()
     }
 
-    /// Builds a query over this model type and invokes ``Query/isEmpty(isolation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/isEmpty(isolation:)`` on that query.
     static func isEmpty(isolation: isolated (any ModelActor) = #isolation) throws -> Bool {
         try query().isEmpty()
     }
 
-    /// Builds a query over this model type and invokes ``Query/findOrCreate(isolation:body:operation:)`` on that query.
+    /// Constructs an empty query over this model type and invokes ``Query/findOrCreate(isolation:body:)`` on that query.
     static func findOrCreate(
         isolation: isolated (any ModelActor) = #isolation,
         body: () -> Self
     ) throws -> Self {
         try query().findOrCreate(body: body)
+    }
+
+    /// Constructs an empty query over this model type and invokes ``Query/delete(isolation:)`` on that query.
+    /// This is named `deleteAll` rather than `delete` to signify with an empty query this will match all objects.
+    static func deleteAll(
+        isolation: isolated (any ModelActor) = #isolation
+    ) throws {
+        try query().delete()
     }
 }

--- a/Sources/SwiftQuery/PersistentModel+Query.swift
+++ b/Sources/SwiftQuery/PersistentModel+Query.swift
@@ -72,4 +72,9 @@ public extension PersistentModel {
     static func prefetchRelationship(_ keyPath: PartialKeyPath<Self>) -> Query<Self> {
         query().prefetchRelationship(keyPath)
     }
+
+    /// Constructs an empty query over this model type and invokes ``Query/fetchKeyPaths(_:)`` on that query.
+    static func fetchKeyPaths(_ keyPaths: PartialKeyPath<Self>...) -> Query<Self> {
+        query().fetchKeyPaths(keyPaths)
+    }
 }

--- a/Sources/SwiftQuery/PersistentModel+Query.swift
+++ b/Sources/SwiftQuery/PersistentModel+Query.swift
@@ -68,9 +68,9 @@ public extension PersistentModel {
 }
 
 public extension PersistentModel {
-    /// Constructs an empty query over this model type and invokes ``Query/prefetchRelationship(_:)`` on that query.
-    static func prefetchRelationship(_ keyPath: PartialKeyPath<Self>) -> Query<Self> {
-        query().prefetchRelationship(keyPath)
+    /// Constructs an empty query over this model type and invokes ``Query/prefetchRelationships(_:)`` on that query.
+    static func prefetchRelationships(_ keyPaths: PartialKeyPath<Self>...) -> Query<Self> {
+        query().prefetchRelationships(keyPaths)
     }
 
     /// Constructs an empty query over this model type and invokes ``Query/fetchKeyPaths(_:)`` on that query.

--- a/Sources/SwiftQuery/PersistentModel+Query.swift
+++ b/Sources/SwiftQuery/PersistentModel+Query.swift
@@ -2,18 +2,24 @@ import Foundation
 import SwiftData
 
 public extension PersistentModel {
+    /// Constructs an empty query over this model type.
+    static func query(_ query: Query<Self> = .init()) -> Query<Self> {
+        query
+    }
+}
+
+public extension PersistentModel {
+    /// Constructs an empty query over this model type and invokes ``Query/include(_:)`` on that query.
     static func include(_ predicate: Predicate<Self>) -> Query<Self> {
         query().include(predicate)
     }
 
+    /// Constructs an empty query over this model type and invokes ``Query/exclude(_:)`` on that query.
     static func exclude(_ predicate: Predicate<Self>) -> Query<Self> {
         query().exclude(predicate)
     }
 
-    static func query(_ query: Query<Self> = .init()) -> Query<Self> {
-        query
-    }
-
+    /// Constructs an empty query over this model type and invokes ``Query/subscript(_:)`` on that query.
     static subscript(_ range: Range<Int>) -> Query<Self> {
         get {
             query()[range]
@@ -22,6 +28,7 @@ public extension PersistentModel {
 }
 
 public extension PersistentModel {
+    /// Constructs an empty query over this model type and invokes ``Query/sortBy(_:order:)`` on that query.
     static func sortBy<Value>(
         _ keyPath: any KeyPath<Self, Value> & Sendable,
         order: SortOrder = .forward
@@ -31,6 +38,7 @@ public extension PersistentModel {
         query().sortBy(keyPath, order: order)
     }
 
+    /// Constructs an empty query over this model type and invokes ``Query/sortBy(_:order:)`` on that query.
     static func sortBy<Value>(
         _ keyPath: any KeyPath<Self, Value?> & Sendable,
         order: SortOrder = .forward
@@ -40,7 +48,7 @@ public extension PersistentModel {
         query().sortBy(keyPath, order: order)
     }
 
-
+    /// Constructs an empty query over this model type and invokes ``Query/sortBy(_:comparator:order:)`` on that query.
     static func sortBy(
         _ keyPath: any KeyPath<Self, String> & Sendable,
         comparator: String.StandardComparator = .localizedStandard,
@@ -49,11 +57,19 @@ public extension PersistentModel {
         query().sortBy(keyPath, comparator: comparator, order: order)
     }
 
+    /// Constructs an empty query over this model type and invokes ``Query/sortBy(_:comparator:order:)`` on that query.
     static func sortBy(
         _ keyPath: any KeyPath<Self, String?> & Sendable,
         comparator: String.StandardComparator = .localizedStandard,
         order: SortOrder = .forward
     ) -> Query<Self> {
         query().sortBy(keyPath, comparator: comparator, order: order)
+    }
+}
+
+public extension PersistentModel {
+    /// Constructs an empty query over this model type and invokes ``Query/prefetchRelationship(_:)`` on that query.
+    static func prefetchRelationship(_ keyPath: PartialKeyPath<Self>) -> Query<Self> {
+        query().prefetchRelationship(keyPath)
     }
 }

--- a/Sources/SwiftQuery/Query.swift
+++ b/Sources/SwiftQuery/Query.swift
@@ -37,9 +37,11 @@ public struct Query<T: PersistentModel> {
     
     /// A range representing the number of results to skip before returning matches and maximum number of results to fetch. When `nil`, the query will return all matching results.
     public var range: Range<Int>?
-
+    
+    /// Key paths representing related models to fetch as part of this query.
     public var relationshipKeyPaths: [PartialKeyPath<T>] = []
-
+    
+    /// The subset of attributes to fetch for this entity
     public var propertiesToFetch: [PartialKeyPath<T>] = []
 
     /// SwiftData compatible sort descriptors generated from the query's sort configuration.
@@ -298,35 +300,40 @@ public extension Query {
 }
 
 public extension Query {
-    /// Returns a new query that prefetches the specified relationship when executing the fetch.
+    /// Returns a new query that prefetches the specified relationships when executing the fetch.
     ///
     /// Prefetching relationships can improve performance by reducing the number of database
-    /// trips needed when accessing related objects. Multiple relationships can be prefetched
-    /// by chaining multiple calls to this method.
+    /// trips needed when accessing related objects.
     ///
-    /// - Parameter keyPath: Key path to the relationship property to prefetch
-    /// - Returns: A new query with the additional relationship marked for prefetching
-    ///
-    /// ## Example
-    /// ```swift
-    /// // Prefetch single relationship
-    /// let ordersWithCustomers = Order
-    ///     .include(#Predicate { $0.status == .active })
-    ///     .prefetchRelationship(\.customer)
-    ///
-    /// // Prefetch multiple relationships
-    /// let ordersWithDetails = Order
-    ///     .prefetchRelationship(\.customer)
-    ///     .prefetchRelationship(\.items)
-    /// ```
-    func prefetchRelationship(_ keyPath: PartialKeyPath<T>) -> Self {
+    /// - Parameter keyPaths: Array of key paths to the relationships to prefetch
+    /// - Returns: A new query with the additional relationships marked for prefetching
+    func prefetchRelationships(_ keyPaths: [PartialKeyPath<T>]) -> Self {
         Query(
             predicate: predicate,
             sortBy: sortBy,
             range: range,
-            prefetchRelationships: relationshipKeyPaths + [keyPath],
+            prefetchRelationships: relationshipKeyPaths + keyPaths,
             propertiesToFetch: propertiesToFetch
         )
+    }
+    
+    /// Returns a new query that prefetches the specified relationships when executing the fetch.
+    ///
+    /// Prefetching relationships can improve performance by reducing the number of database
+    /// trips needed when accessing related objects.
+    ///
+    /// - Parameter keyPaths: Key paths to the relationships to prefetch
+    /// - Returns: A new query with the additional relationships marked for prefetching
+    ///
+    /// ## Example
+    /// ```swift
+    /// // Prefetch multiple relationships
+    /// let ordersWithDetails = Order
+    ///     .include(#Predicate { $0.status == .active })
+    ///     .prefetchRelationships(\.customer, \.items)
+    /// ```
+    func prefetchRelationships(_ keyPaths: PartialKeyPath<T>...) -> Self {
+        prefetchRelationships(keyPaths)
     }
 
     /// Returns a new query that fetches only the specified key paths when executing the fetch.

--- a/Tests/SwiftQueryTests/FetchWrapperTests.swift
+++ b/Tests/SwiftQueryTests/FetchWrapperTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Dependencies
+import IssueReporting
+import SwiftData
+import SwiftQuery
+import Testing
+
+@MainActor
+struct FetchWrapperTests {
+    let modelContainer: ModelContainer
+
+    init() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        modelContainer = try ModelContainer(for: Person.self, configurations: config)
+    }
+
+    @Test func fetchFirst_reflectsChanges() async throws {
+        try await withDependencies {
+            $0.modelContainer = modelContainer
+        } operation: {
+            @FetchFirst(.jack)
+            var jack: Person?
+            #expect(jack == nil)
+
+            modelContainer.mainContext.insert(Person(name: "Jack", age: 25))
+            try modelContainer.mainContext.save()
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(jack != nil)
+            #expect(jack?.age == 25)
+            
+            jack?.age = 30
+            try modelContainer.mainContext.save()
+            
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(jack?.age == 30)
+        }
+    }
+
+    @Test func fetchAll_reflectsChanges() async throws {
+        try await withDependencies {
+            $0.modelContainer = modelContainer
+        } operation: {
+            @FetchAll(.adults) var adults: [Person]
+
+            #expect(adults.isEmpty)
+
+            let alice = Person(name: "Alice", age: 25)
+            let bob = Person(name: "Bob", age: 30)
+            let charlie = Person(name: "Charlie", age: 20)
+
+            try modelContainer.mainContext.transaction {
+                modelContainer.mainContext.insert(alice)
+                modelContainer.mainContext.insert(bob)
+                modelContainer.mainContext.insert(charlie)
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(adults.count == 2)
+            #expect(adults[0].name == "Alice")
+            #expect(adults[1].name == "Bob")
+
+            try modelContainer.mainContext.transaction {
+                charlie.age = 35
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(adults.count == 3)
+            #expect(adults[2].name == "Charlie")
+            #expect(adults[2].age == 35)
+
+            try modelContainer.mainContext.transaction {
+                modelContainer.mainContext.delete(bob)
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(adults.count == 2)
+            #expect(adults[0].name == "Alice")
+            #expect(adults[1].name == "Charlie")
+        }
+    }
+
+    @Test func fetchResults_reflectsChanges() async throws {
+        try await withDependencies {
+            $0.modelContainer = modelContainer
+        } operation: {
+            @FetchResults(.adults) var adults: FetchResultsCollection<Person>?
+
+            #expect(adults == nil)
+
+            let alice = Person(name: "Alice", age: 25)
+            let bob = Person(name: "Bob", age: 30)
+            let charlie = Person(name: "Charlie", age: 20)
+
+            try modelContainer.mainContext.transaction {
+                modelContainer.mainContext.insert(alice)
+                modelContainer.mainContext.insert(bob)
+                modelContainer.mainContext.insert(charlie)
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            let adultsResults = try #require(adults)
+
+            #expect(adultsResults.count == 2)
+            #expect(adultsResults[0].name == "Alice")
+            #expect(adultsResults[1].name == "Bob")
+
+            try modelContainer.mainContext.transaction {
+                charlie.age = 35
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(adultsResults.count == 3)
+//            #expect(adultsResults[2].name == "Charlie")
+//            #expect(adultsResults[2].age == 35)
+//
+//            try modelContainer.mainContext.transaction {
+//                modelContainer.mainContext.delete(bob)
+//            }
+//
+//            try await Task.sleep(nanoseconds: 100_000_000)
+//
+//            #expect(adultsResults.count == 2)
+//            #expect(adultsResults[0].name == "Alice")
+//            #expect(adultsResults[1].name == "Charlie")
+        }
+    }
+
+//    @Test func recordsIssue_whenMissingModelContainer() {
+//        withKnownIssue {
+//            @FetchFirst(
+//                predicate: #Predicate<Person> { $0.name == "Test" }
+//            ) var person: Person?
+//        }
+//    }
+
+}
+
+
+extension Query where T == Person {
+    static var jack: Query {
+        Person
+            .include(#Predicate<Person> { $0.name == "Jack" })
+    }
+
+
+    static var adults: Query {
+        Person
+            .include(#Predicate<Person> { $0.age >= 25 })
+            .sortBy(\.age, order: .forward)
+    }
+}

--- a/Tests/SwiftQueryTests/FetchWrapperTests.swift
+++ b/Tests/SwiftQueryTests/FetchWrapperTests.swift
@@ -104,11 +104,10 @@ struct FetchWrapperTests {
 
             try await Task.sleep(nanoseconds: 100_000_000)
 
-            let adultsResults = try #require(adults)
-
-            #expect(adultsResults.count == 2)
-            #expect(adultsResults[0].name == "Alice")
-            #expect(adultsResults[1].name == "Bob")
+            #expect(adults != nil)
+            #expect(adults?.count == 2)
+            #expect(adults?[0].name == "Alice")
+            #expect(adults?[1].name == "Bob")
 
             try modelContainer.mainContext.transaction {
                 charlie.age = 35
@@ -116,19 +115,19 @@ struct FetchWrapperTests {
 
             try await Task.sleep(nanoseconds: 100_000_000)
 
-            #expect(adultsResults.count == 3)
-//            #expect(adultsResults[2].name == "Charlie")
-//            #expect(adultsResults[2].age == 35)
-//
-//            try modelContainer.mainContext.transaction {
-//                modelContainer.mainContext.delete(bob)
-//            }
-//
-//            try await Task.sleep(nanoseconds: 100_000_000)
-//
-//            #expect(adultsResults.count == 2)
-//            #expect(adultsResults[0].name == "Alice")
-//            #expect(adultsResults[1].name == "Charlie")
+            #expect(adults?.count == 3)
+            #expect(adults?[2].name == "Charlie")
+            #expect(adults?[2].age == 35)
+
+            try modelContainer.mainContext.transaction {
+                modelContainer.mainContext.delete(bob)
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            #expect(adults?.count == 2)
+            #expect(adults?[0].name == "Alice")
+            #expect(adults?[1].name == "Charlie")
         }
     }
 

--- a/Tests/SwiftQueryTests/FetchWrapperTests.swift
+++ b/Tests/SwiftQueryTests/FetchWrapperTests.swift
@@ -18,8 +18,7 @@ struct FetchWrapperTests {
         try await withDependencies {
             $0.modelContainer = modelContainer
         } operation: {
-            @FetchFirst(.jack)
-            var jack: Person?
+            @FetchFirst(.jack) var jack: Person?
             #expect(jack == nil)
 
             modelContainer.mainContext.insert(Person(name: "Jack", age: 25))
@@ -131,23 +130,18 @@ struct FetchWrapperTests {
         }
     }
 
-//    @Test func recordsIssue_whenMissingModelContainer() {
-//        withKnownIssue {
-//            @FetchFirst(
-//                predicate: #Predicate<Person> { $0.name == "Test" }
-//            ) var person: Person?
-//        }
-//    }
-
+    @Test func recordsIssue_whenMissingModelContainer() {
+        withKnownIssue {
+            @FetchFirst(.jack) var jack: Person?
+        }
+    }
 }
-
 
 extension Query where T == Person {
     static var jack: Query {
         Person
             .include(#Predicate<Person> { $0.name == "Jack" })
     }
-
 
     static var adults: Query {
         Person

--- a/Tests/SwiftQueryTests/PersistentModelFetchTests.swift
+++ b/Tests/SwiftQueryTests/PersistentModelFetchTests.swift
@@ -78,6 +78,15 @@ struct PersistentModelFetchTests {
         #expect(modelResult.age == directResult.age)
         #expect(modelResult.age != 999) // Should find existing, not create new
     }
+
+    @Test func deleteAll() throws {
+        #expect(try Person.count(in: modelContainer) == 3)
+        
+        try Person.deleteAll(in: modelContainer)
+        
+        #expect(try Person.count(in: modelContainer) == 0)
+        #expect(try Person.isEmpty(in: modelContainer) == true)
+    }
 }
 
 struct PersistentModelConcurrentFetchTests {
@@ -165,6 +174,17 @@ struct PersistentModelConcurrentFetchTests {
             #expect(modelPerson.name == directPerson.name)
             #expect(modelPerson.age == directPerson.age)
             #expect(modelPerson.age != 999) // Should find existing, not create new
+        }
+    }
+
+    @Test func deleteAll() async throws {
+        try await modelContainer.createQueryActor().perform { _ in
+            #expect(try Person.count() == 3)
+            
+            try Person.deleteAll()
+            
+            #expect(try Person.count() == 0)
+            #expect(try Person.isEmpty() == true)
         }
     }
 }

--- a/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
+++ b/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
@@ -61,9 +61,9 @@ struct PersistentModelQueryTests {
         #expect(modelQuery.sortDescriptors.first?.order == directQuery.sortDescriptors.first?.order)
     }
 
-    @Test func prefetchRelationship() async throws {
-        let modelQuery = Person.prefetchRelationship(\.name)
-        let directQuery = Query<Person>().prefetchRelationship(\.name)
+    @Test func prefetchRelationships() async throws {
+        let modelQuery = Person.prefetchRelationships(\.name)
+        let directQuery = Query<Person>().prefetchRelationships(\.name)
         
         #expect(modelQuery.relationshipKeyPaths.count == directQuery.relationshipKeyPaths.count)
         #expect(modelQuery.relationshipKeyPaths.contains(\Person.name) == directQuery.relationshipKeyPaths.contains(\Person.name))

--- a/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
+++ b/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
@@ -68,4 +68,12 @@ struct PersistentModelQueryTests {
         #expect(modelQuery.relationshipKeyPaths.count == directQuery.relationshipKeyPaths.count)
         #expect(modelQuery.relationshipKeyPaths.contains(\Person.name) == directQuery.relationshipKeyPaths.contains(\Person.name))
     }
+
+    @Test func fetchKeyPaths() async throws {
+        let modelQuery = Person.fetchKeyPaths(\.name)
+        let directQuery = Query<Person>().fetchKeyPaths(\.name)
+        
+        #expect(modelQuery.propertiesToFetch.count == directQuery.propertiesToFetch.count)
+        #expect(modelQuery.propertiesToFetch.contains(\Person.name) == directQuery.propertiesToFetch.contains(\Person.name))
+    }
 }

--- a/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
+++ b/Tests/SwiftQueryTests/PersistentModelQueryTests.swift
@@ -60,4 +60,12 @@ struct PersistentModelQueryTests {
         #expect(modelQuery.sortDescriptors.count == directQuery.sortDescriptors.count)
         #expect(modelQuery.sortDescriptors.first?.order == directQuery.sortDescriptors.first?.order)
     }
+
+    @Test func prefetchRelationship() async throws {
+        let modelQuery = Person.prefetchRelationship(\.name)
+        let directQuery = Query<Person>().prefetchRelationship(\.name)
+        
+        #expect(modelQuery.relationshipKeyPaths.count == directQuery.relationshipKeyPaths.count)
+        #expect(modelQuery.relationshipKeyPaths.contains(\Person.name) == directQuery.relationshipKeyPaths.contains(\Person.name))
+    }
 }

--- a/Tests/SwiftQueryTests/QueryTests.swift
+++ b/Tests/SwiftQueryTests/QueryTests.swift
@@ -327,5 +327,4 @@ struct QueryTests {
         #expect(query.propertiesToFetch.count == 1)
         #expect(query.propertiesToFetch.contains(\Person.age))
     }
-
 }

--- a/Tests/SwiftQueryTests/QueryTests.swift
+++ b/Tests/SwiftQueryTests/QueryTests.swift
@@ -269,4 +269,34 @@ struct QueryTests {
         }
     }
 
+    @Test func prefetchRelationship_single() async throws {
+        let query = Query<Person>()
+            .prefetchRelationship(\.name)
+        
+        #expect(query.relationshipKeyPaths.count == 1)
+        #expect(query.relationshipKeyPaths.contains(\Person.name))
+    }
+
+    @Test func prefetchRelationship_multiple() async throws {
+        let query = Query<Person>()
+            .prefetchRelationship(\.name)
+            .prefetchRelationship(\.age)
+        
+        #expect(query.relationshipKeyPaths.count == 2)
+        #expect(query.relationshipKeyPaths.contains(\Person.name))
+        #expect(query.relationshipKeyPaths.contains(\Person.age))
+    }
+
+    @Test func prefetchRelationship_withOtherModifiers() async throws {
+        let predicate = #Predicate<Person> { $0.age >= 18 }
+        let query = Person.include(predicate)
+            .sortBy(\.name)
+            .prefetchRelationship(\.age)
+        
+        #expect(query.predicate != nil)
+        #expect(query.sortBy.count == 1)
+        #expect(query.relationshipKeyPaths.count == 1)
+        #expect(query.relationshipKeyPaths.contains(\Person.age))
+    }
+
 }

--- a/Tests/SwiftQueryTests/QueryTests.swift
+++ b/Tests/SwiftQueryTests/QueryTests.swift
@@ -299,4 +299,33 @@ struct QueryTests {
         #expect(query.relationshipKeyPaths.contains(\Person.age))
     }
 
+    @Test func fetchKeyPaths_single() async throws {
+        let query = Query<Person>()
+            .fetchKeyPaths(\.name)
+        
+        #expect(query.propertiesToFetch.count == 1)
+        #expect(query.propertiesToFetch.contains(\Person.name))
+    }
+
+    @Test func fetchKeyPaths_multiple() async throws {
+        let query = Query<Person>()
+            .fetchKeyPaths(\.name, \.age)
+        
+        #expect(query.propertiesToFetch.count == 2)
+        #expect(query.propertiesToFetch.contains(\Person.name))
+        #expect(query.propertiesToFetch.contains(\Person.age))
+    }
+
+    @Test func fetchKeyPaths_withOtherModifiers() async throws {
+        let predicate = #Predicate<Person> { $0.age >= 18 }
+        let query = Person.include(predicate)
+            .sortBy(\.name)
+            .fetchKeyPaths(\.age)
+        
+        #expect(query.predicate != nil)
+        #expect(query.sortBy.count == 1)
+        #expect(query.propertiesToFetch.count == 1)
+        #expect(query.propertiesToFetch.contains(\Person.age))
+    }
+
 }

--- a/Tests/SwiftQueryTests/QueryTests.swift
+++ b/Tests/SwiftQueryTests/QueryTests.swift
@@ -269,29 +269,28 @@ struct QueryTests {
         }
     }
 
-    @Test func prefetchRelationship_single() async throws {
+    @Test func prefetchRelationships_single() async throws {
         let query = Query<Person>()
-            .prefetchRelationship(\.name)
+            .prefetchRelationships(\.name)
         
         #expect(query.relationshipKeyPaths.count == 1)
         #expect(query.relationshipKeyPaths.contains(\Person.name))
     }
 
-    @Test func prefetchRelationship_multiple() async throws {
+    @Test func prefetchRelationships_multiple() async throws {
         let query = Query<Person>()
-            .prefetchRelationship(\.name)
-            .prefetchRelationship(\.age)
+            .prefetchRelationships(\.name, \.age)
         
         #expect(query.relationshipKeyPaths.count == 2)
         #expect(query.relationshipKeyPaths.contains(\Person.name))
         #expect(query.relationshipKeyPaths.contains(\Person.age))
     }
 
-    @Test func prefetchRelationship_withOtherModifiers() async throws {
+    @Test func prefetchRelationships_withOtherModifiers() async throws {
         let predicate = #Predicate<Person> { $0.age >= 18 }
         let query = Person.include(predicate)
             .sortBy(\.name)
-            .prefetchRelationship(\.age)
+            .prefetchRelationships(\.age)
         
         #expect(query.predicate != nil)
         #expect(query.sortBy.count == 1)


### PR DESCRIPTION
  1. Observable fetch wrappers

  Added property wrappers that automatically update when data matching a query changes:
  - FetchFirst - Tracks first result matching a query
  - FetchAll - Tracks all results matching a query
  - FetchResults - Tracks results as lazy collection with batch size

  2. Relationship prefetching

  Added prefetchRelationship() to reduce database trips when accessing related objects and support fetch wrappers returning a larger portion of the graph. 

  3. Fetch specific properties

  Added fetchKeyPaths() to fetch only specific properties, which can improve performance for a given fetch. 